### PR TITLE
Fix: Generated SQL is wrong with filters in joined table #1032

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -285,6 +285,11 @@ export const buildQuery = ({
     const selectedTables = new Set([
         ...metrics.map((field) => getMetricFromId(field, explore).table),
         ...dimensions.map((field) => getDimensionFromId(field, explore).table),
+        ...filters.map(
+            (filterGroup) =>
+                getDimensionFromId(fieldIdFromFilterGroup(filterGroup), explore)
+                    .table,
+        ),
     ]);
 
     const sqlJoins = explore.joinedTables


### PR DESCRIPTION
### Reference:
Closes: #1032

### Description:
my first contribution, feat #905 was too specific with choosing the join tables and didn't account for the scenario where you might filter the explore from a table that wasn't the table of a dimension or metric or the explore main table thus causing #1032.

The querybuilder.mock should have some filters specified in the filters arrays so that this scenario gets tested in future, but I'm not sure of the format to put in there. There are no other examples in the mockers in the codebase as far as I can see.

- [ ] Backend 