### PR TITLE
feat: Make timeinterval default #999

### DIFF
--- a/docs/docs/references/dimensions.md
+++ b/docs/docs/references/dimensions.md
@@ -52,7 +52,7 @@ All the properties you can customize:
 | type            | Dimension type        | |
 | description     | string                | |
 | sql             | string                | |
-| time_intervals  | `'default'` or string[] | `'default'` will be converted into `['DAY', 'WEEK', 'MONTH', 'YEAR']` for dates and `['MILLISECOND', 'DAY', 'WEEK', 'MONTH', 'YEAR']` for timestamps |
+| time_intervals  | `'default'` or string[] | `'default'` will be converted into `['DAY', 'WEEK', 'MONTH', 'YEAR']` for dates and `['RAW', 'DAY', 'WEEK', 'MONTH', 'YEAR']` for timestamps, as will not setting anything; if you want no time intervals set 'OFF' |
 
 
 ## Dimension types

--- a/packages/backend/src/dbt/translator.mock.ts
+++ b/packages/backend/src/dbt/translator.mock.ts
@@ -65,6 +65,30 @@ const COLUMN_WITH_DEFAULT_TIME_INTERVALS: Record<string, DbtModelColumn> = {
     },
 };
 
+const COLUMN_WITH_NO_TIME_INTERVALS: Record<string, DbtModelColumn> = {
+    user_created: {
+        name: 'user_created',
+        data_type: DimensionType.TIMESTAMP,
+        meta: {
+            dimension: {
+                time_intervals: undefined,
+            },
+        },
+    },
+};
+
+const COLUMN_WITH_OFF_TIME_INTERVALS: Record<string, DbtModelColumn> = {
+    user_created: {
+        name: 'user_created',
+        data_type: DimensionType.TIMESTAMP,
+        meta: {
+            dimension: {
+                time_intervals: 'OFF',
+            },
+        },
+    },
+};
+
 const COLUMN_WITH_CUSTOM_TIME_INTERVALS: Record<string, DbtModelColumn> = {
     user_created: {
         name: 'user_created',
@@ -254,6 +278,121 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS: Omit<
             source: undefined,
             group: 'user_created',
             timeInterval: 'YEAR',
+        },
+    },
+    metrics: {},
+};
+
+export const MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS: DbtModelNode = {
+    ...model,
+    columns: COLUMN_WITH_NO_TIME_INTERVALS,
+};
+
+export const LIGHTDASH_TABLE_WITH_NO_TIME_INTERVAL_DIMENSIONS: Omit<
+    Table,
+    'lineageGraph'
+> = {
+    name: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+    database: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.database,
+    schema: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.schema,
+    sqlTable: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.relation_name,
+    description: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.description,
+    dimensions: {
+        user_created: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.TIMESTAMP,
+            sql: '${TABLE}.user_created',
+            name: 'user_created',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: undefined,
+            timeInterval: undefined,
+        },
+        user_created_RAW: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.TIMESTAMP,
+            sql: '${TABLE}.user_created',
+            name: 'user_created_raw',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: 'user_created',
+            timeInterval: 'RAW',
+        },
+        user_created_DAY: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.DATE,
+            sql: "DATE_TRUNC('${TABLE}.user_created', DAY)",
+            name: 'user_created_day',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: 'user_created',
+            timeInterval: 'DAY',
+        },
+        user_created_WEEK: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.DATE,
+            sql: "DATE_TRUNC('${TABLE}.user_created', WEEK)",
+            name: 'user_created_week',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: 'user_created',
+            timeInterval: 'WEEK',
+        },
+        user_created_MONTH: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.DATE,
+            sql: "DATE_TRUNC('${TABLE}.user_created', MONTH)",
+            name: 'user_created_month',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: 'user_created',
+            timeInterval: 'MONTH',
+        },
+        user_created_YEAR: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.DATE,
+            sql: "DATE_TRUNC('${TABLE}.user_created', YEAR)",
+            name: 'user_created_year',
+            table: MODEL_WITH_NO_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: 'user_created',
+            timeInterval: 'YEAR',
+        },
+    },
+    metrics: {},
+};
+
+export const MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS: DbtModelNode = {
+    ...model,
+    columns: COLUMN_WITH_OFF_TIME_INTERVALS,
+};
+
+export const LIGHTDASH_TABLE_WITH_OFF_TIME_INTERVAL_DIMENSIONS: Omit<
+    Table,
+    'lineageGraph'
+> = {
+    name: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.name,
+    database: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.database,
+    schema: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.schema,
+    sqlTable: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.relation_name,
+    description: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.description,
+    dimensions: {
+        user_created: {
+            fieldType: FieldType.DIMENSION,
+            description: undefined,
+            type: DimensionType.TIMESTAMP,
+            sql: '${TABLE}.user_created',
+            name: 'user_created',
+            table: MODEL_WITH_OFF_TIME_INTERVAL_DIMENSIONS.name,
+            source: undefined,
+            group: undefined,
+            timeInterval: undefined,
         },
     },
     metrics: {},

--- a/packages/backend/src/dbt/translator.ts
+++ b/packages/backend/src/dbt/translator.ts
@@ -253,7 +253,7 @@ export const convertTable = (
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                     dimension.type,
                 ) &&
-                column.meta.dimension?.time_intervals
+                column.meta.dimension?.time_intervals !== 'OFF'
             ) {
                 let intervals: string[] = [];
                 if (Array.isArray(column.meta.dimension.time_intervals)) {

--- a/packages/backend/src/dbt/translator.ts
+++ b/packages/backend/src/dbt/translator.ts
@@ -253,10 +253,15 @@ export const convertTable = (
                 [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                     dimension.type,
                 ) &&
-                column.meta.dimension?.time_intervals !== 'OFF'
+                ((column.meta.dimension?.time_intervals &&
+                    column.meta.dimension.time_intervals !== 'OFF') ||
+                    !column.meta.dimension?.time_intervals)
             ) {
                 let intervals: string[] = [];
-                if (Array.isArray(column.meta.dimension.time_intervals)) {
+                if (
+                    column.meta.dimension?.time_intervals &&
+                    Array.isArray(column.meta.dimension.time_intervals)
+                ) {
                     intervals = column.meta.dimension.time_intervals;
                 } else {
                     if (dimension.type === DimensionType.TIMESTAMP) {


### PR DESCRIPTION
### Reference:
Closes: #999

### Description:
changes to add time intervals by default to timestamp and date fields unless specified 'OFF' in yaml

### Scope of the changes (select all that apply):
- [ ] Backend  
- [ ] Docs  
